### PR TITLE
Fix critical section in DHT driver

### DIFF
--- a/dht.c
+++ b/dht.c
@@ -43,10 +43,9 @@ static portMUX_TYPE mux = portMUX_INITIALIZER_UNLOCKED;
 
  #define CHECK_ARG(VAL) do { if (!(VAL)) return ESP_ERR_INVALID_ARG; } while (0)
 
- #define CHECK_LOGE(x, msg, ...) do { \
+#define CHECK_LOGE(x, msg, ...) do { \
                 esp_err_t __err = (x); \
                 if (__err != ESP_OK) { \
-                        PORT_EXIT_CRITICAL(); \
                         ESP_LOGE(TAG, msg, ## __VA_ARGS__); \
                         return __err; \
                 } \


### PR DESCRIPTION
## Summary
- fix CHECK_LOGE macro so caller handles critical section exits

## Testing
- `gcc -c dht.c -Iinclude` *(fails: driver/gpio.h: No such file or directory)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6841705765ec8321b41eecb3964097da